### PR TITLE
Lower weight for PR opened by user in their own repo

### DIFF
--- a/leaderboard/constants/scoreWeights.py
+++ b/leaderboard/constants/scoreWeights.py
@@ -1,8 +1,8 @@
 # score weights for each of the sub types
 T1S1 = 1  # score for 'PR opened in a repo not owned by the user'
-T1S2 = 1  # score for 'PR opened in a repo owned by the user'
-T2S1 = 0.5  # score for 'PR reviewed that is opened by the user and contributed in the repo owned by the use'
-T2S2 = 0.5  # score for 'PR reviewed that is not opened by the user and contributed in the repo owned by the use'
+T1S2 = 0.6  # score for 'PR opened in a repo owned by the user'
+T2S1 = 0.5  # score for 'PR reviewed that is opened by the user and contributed in the repo owned by the user'
+T2S2 = 0.5  # score for 'PR reviewed that is not opened by the user and contributed in the repo owned by the user'
 T2S3 = 0.5  # score for 'PR reviewed that is opened by the user and contributed in the repo not owned by the user'
 T2S4 = 0.5  # score for 'PR reviewed that is not opened by the user and contributed in the repo not owned by the user'
 T3S1 = 0.3  # score for 'Issue created in a repo owned by the user'


### PR DESCRIPTION
Lower the weight of PR opened by the same owner to `0.6`.

I think it makes sense to promote contributions to repositories outside of the one created by the use that they may be familiar with.