### PR TITLE
Add additional check for null in mergedBy

### DIFF
--- a/leaderboard/utils/formatter.py
+++ b/leaderboard/utils/formatter.py
@@ -241,8 +241,8 @@ def format_pr_contributions(
 
         merged_by_id = ""
         if pr_node["merged"] and pr_node["mergedBy"]:
-            mb  = pr_node["mergedBy"]
-            if "id" in mb: 
+            mb = pr_node["mergedBy"]
+            if "id" in mb:
                 merged_by_id = pr_node["mergedBy"]["id"]
         labels = []
         do_not_continue = False

--- a/leaderboard/utils/formatter.py
+++ b/leaderboard/utils/formatter.py
@@ -240,9 +240,10 @@ def format_pr_contributions(
         commits = pr_node["commits"]["totalCount"]
 
         merged_by_id = ""
-        if pr_node["merged"]:
-            merged_by_id = pr_node["mergedBy"]["id"]
-
+        if pr_node["merged"] and pr_node["mergedBy"]:
+            mb  = pr_node["mergedBy"]
+            if "id" in mb: 
+                merged_by_id = pr_node["mergedBy"]["id"]
         labels = []
         do_not_continue = False
         for edge in pr_node["labels"]["edges"]:


### PR DESCRIPTION
## Description
 - When PRs are merged by github action we do not have the id.  This causes the build to fail.
 -  Add additional check null check for `mergedBy`.