### PR TITLE
Cache pip dependencies

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,14 +11,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo content
-        uses: actions/checkout@v2 # checkout the repository content to github runner.
+        uses: actions/checkout@v3
+
       - name: Setup python
-        uses: actions/setup-python@v3 # install python.
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: setup.py
+
       - name: Install dependencies
-        run: make setup # run setup from Makefile.
+        run: make setup
+
       - name: Install pyright
         run: npm install -g pyright@1.1.45
+
       - name: Check
-        run: make check # run check from Makefile.
+        run: make check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,18 +5,25 @@ on:
       - master
   schedule:
     - cron: 0 0 * * * # Every Midnight
-  workflow_dispatch: 
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repo content
-        uses: actions/checkout@v2 # checkout the repository content to github runner.
+        uses: actions/checkout@v3
+
       - name: Setup python
-        uses: actions/setup-python@v2 # install python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: setup.py
+
       - name: Install dependencies
-        run: python3 -m pip install .
+        run: make setup
+
       - name: Run python code and generate html file
         run: python main.py
         env:
@@ -25,15 +32,18 @@ jobs:
           DURATION_IN_DAYS: 5
           PAGE_DATA_COUNT: 5
           START_DATE: ${{ secrets.START_DATE }}
+
       - name: Create assets
         run: |
           mkdir -p ./build/assets
+
       - name: Copy assets
         uses: canastro/copy-file-action@master # copy style.css
         with:
           source: './assets/.'
           target: './build/assets/.'
           flags: '-r'
+
       - name: Upload to netlify
         uses: South-Paw/action-netlify-deploy@v1.0.4 # deploy to netlify
         with:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as f:
 
 requirements = [
     "requests==2.31.0",
-    "pandas==1.2.0",
+    "pandas==1.5.3",
     "tabulate==0.8.7",
     "markdown==3.2.2",
 ]


### PR DESCRIPTION
It is taking forever to install pandas because it is building the wheel. Cache pip dependencies so that installation is faster + use (pandas + python) version that doesn't need to build a wheel. 

https://github.com/Lf-Network/oss-leaderboard/actions/runs/6391261496/job/17346150509

Bonus:

- Update old actions to new version: `actions/checkout` and `actions/setup-python`