### PR TITLE
Update deprecated `method_whitelist`

### DIFF
--- a/leaderboard/fetch_data.py
+++ b/leaderboard/fetch_data.py
@@ -34,7 +34,7 @@ def execute_query(query: str, variables: Dict) -> requests.models.Response:
         total=5,
         backoff_factor=0.8,
         status_forcelist=[500, 502, 503, 504],
-        method_whitelist=(["POST"]),
+        allowed_methods=(["POST"]),
     )
 
     s.mount("https://", HTTPAdapter(max_retries=retries))


### PR DESCRIPTION
## Description
- Currently, our github action is failing as we are using `method_whitelist` which is deprecated. ([Reference](https://github.com/urllib3/urllib3/issues/2092))
- Replace `method_whitelist` with `allowed_methods`