### PR TITLE
Update Dockerfile to run oss-leaderboard scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,8 @@
-FROM laudio/pyodbc:1.0.33 AS main
+FROM python:3.11-slim AS main
 
-WORKDIR /app
-
-COPY ["setup.py", "README.md", "main.py", "./"]
+COPY ["setup.py", "final_html_output.py", "multi_users_fetch.py", "main.py", "README.md", "./"]
 COPY ["leaderboard", "./leaderboard"]
 
-RUN pip install . 
+RUN pip install -U -e .
 
 CMD ["python", "main.py"]
-
-
-# STAGE: test
-# -----------
-# Image used for running tests.FROM main AS test
-FROM main AS test
-
-RUN pip install .[dev]
-
-COPY ["tests", "./"]
-
-CMD pytest -vvv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM python:3.11-slim AS main
 
+WORKDIR /app
+
 COPY ["setup.py", "final_html_output.py", "multi_users_fetch.py", "main.py", "README.md", "./"]
 COPY ["leaderboard", "./leaderboard"]
+COPY ["assets", "./assets"]
 
 RUN pip install -U -e .
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ clean:
 
 venv:
 	@virtualenv -p python3 $(VENV_PATH)
- 
+
 setup:
 	@pip3 install -U -e .[dev]
 
@@ -21,10 +21,6 @@ venv_test:
 build:
 	@docker build --no-cache --target=test -t leaderboard:test .
 	@docker build --no-cache --target=main -t leaderboard .
-
-test:
-	@docker build --target=test -t leaderboard:test .
-	@docker run leaderboard:test
 
 format:
 	@black .

--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ Make sure to run following commands:
 $ make format
 
 $ make check
-
-$ make test
 ```
 
 ## Intermediate scrore table

--- a/README.md
+++ b/README.md
@@ -46,14 +46,6 @@ $ source .venv/bin/activate
 $ make setup
 ```
 
-#### Running tests
-
-```bash
-$ make test
-```
-
-Note: This ensures all the dependencies are complete since tests are run in an isolated container.
-
 ## Contributing
 
 Feel free to send pull requests.
@@ -61,7 +53,6 @@ Make sure to run following commands:
 
 ```bash
 $ make format
-
 $ make check
 ```
 

--- a/leaderboard/fetch_data.py
+++ b/leaderboard/fetch_data.py
@@ -15,7 +15,7 @@ logger = logging.getLogger("fetch_data")
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
 API_ENDPOINT = "https://api.github.com/graphql"
 
-headers = {"Authorization": GITHUB_TOKEN}
+headers = {"Authorization": "Bearer " + GITHUB_TOKEN}
 
 logger.info(headers)
 

--- a/run-local.sh
+++ b/run-local.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-docker build --no-cache --target main -t leaderboard .
-docker run --env-file .env --mount type=bind,src="$(pwd)",target=/app leaderboard
+
+docker build --no-cache --target main -t oss-leaderboard .
+docker run --env-file .env --mount type=bind,src="$(pwd)",target=/app oss-leaderboard


### PR DESCRIPTION
- Update `Dockerfile` with `python 3.11` as base image (was not updated for a long time)
- Remove test command from `Makefile` and `README.md` as there is nothing to test 🤷 
- Add "Bearer " before token in authorization header (Was receiving 401 when request was sent to GitHub)