### PR TITLE
Change `Bearer` to `token`

### DIFF
--- a/leaderboard/fetch_data.py
+++ b/leaderboard/fetch_data.py
@@ -15,7 +15,7 @@ logger = logging.getLogger("fetch_data")
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
 API_ENDPOINT = "https://api.github.com/graphql"
 
-headers = {"Authorization": "Bearer " + GITHUB_TOKEN}
+headers = {"Authorization": "token " + GITHUB_TOKEN}
 
 logger.info(headers)
 


### PR DESCRIPTION
## Description

- Change `Bearer` to `token` as GraphQL uses to `token` instead of  `Bearer`